### PR TITLE
RClone SMB Timeout issues

### DIFF
--- a/includes/rclone/rclone-mount-template.service
+++ b/includes/rclone/rclone-mount-template.service
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/rclone mount REMOTE-NAME-PLACEHOLDER: REMOTE-MOUNTPOINT-PLACE
 --config DOCKER-FOLDER-PLACEHOLDER/appdata/rclone/rclone.conf \
 --log-file=DOCKER-FOLDER-PLACEHOLDER/logs/HOSTNAME-PLACEHOLDER/rclone-REMOTE-NAME-PLACEHOLDER.log \
 --log-level NOTICE \
+--log-file-max-size 5M \
 --allow-other \
 --no-modtime \
 --umask 002 \
@@ -23,6 +24,7 @@ ExecStart=/usr/bin/rclone mount REMOTE-NAME-PLACEHOLDER: REMOTE-MOUNTPOINT-PLACE
 --vfs-cache-max-size REMOTE-CACHESIZE-PLACEHOLDERG \
 --vfs-read-chunk-size-limit 10G \
 --vfs-refresh \
+--vfs-links \
 #--rc \
 #--rc-web-gui \
 #--rc-addr :5572 \
@@ -33,7 +35,7 @@ ExecStart=/usr/bin/rclone mount REMOTE-NAME-PLACEHOLDER: REMOTE-MOUNTPOINT-PLACE
 --use-mmap
 ExecStop=/bin/fusermount -uz REMOTE-MOUNTPOINT-PLACEHOLDER
 #ExecStartPost=/usr/bin/rclone rc vfs/refresh recursive=true --rc-addr :5572 _async=true
-Restart=on-abort
+Restart=on-failure
 User=USERNAME-PLACEHOLDER
 Group=USERNAME-PLACEHOLDER
 KillMode=mixed
@@ -41,3 +43,4 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
+

--- a/includes/rclone/rclone-template.conf
+++ b/includes/rclone/rclone-template.conf
@@ -3,4 +3,5 @@ type = smb
 host = REMOTE-HOST-PLACEHOLDER
 user = REMOTE-USER-PLACEHOLDER
 pass = REMOTE-PASSWORD-HASHED-PLACEHOLDER
-idle_timeout = 0s
+idle_timeout = 0
+


### PR DESCRIPTION
This pull request makes several improvements to the rclone mount systemd service template and rclone configuration template. The changes focus on log management, mount options, service reliability, and configuration consistency.

**Service template improvements:**

* Added `--log-file-max-size 5M` to limit the size of rclone log files, helping to prevent disk space issues.
* Added `--vfs-links` to the mount options to enable support for symbolic links in the mounted remote.
* Changed the service restart policy from `Restart=on-abort` to `Restart=on-failure` for improved reliability in case of errors.

**Configuration template update:**

* Changed `idle_timeout` from `0s` to `0` for improved consistency and compatibility in the rclone configuration.